### PR TITLE
twitterカードの表示方式変更

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -1,6 +1,6 @@
 class ContentsController < ApplicationController
   def index
-    @contents = Content.joins(:favorites).select('provider', 'url', 'oembed')
+    @contents = Content.joins(:favorites).select('provider', 'source_id', 'url')
                        .order('favorites.id desc').limit(100)
 
     # TODO: URLが重複している場合に除去する

--- a/app/views/contents/index.html.slim
+++ b/app/views/contents/index.html.slim
@@ -7,10 +7,10 @@
       = alert
   .row.row-eq-height
     - @contents.each do |content|
-      div class="col-md-4 col-sm-6"
+      div class="col-md-4 col-sm-6 #{content.provider}-#{content.source_id}"
         - case content.provider
         - when 'twitter'
           blockquote.twitter-tweet data-conversation="none"
-            a href=content.url
+            a class="#{content.provider}-#{content.source_id}" href=content.url
 
 script {async src="//platform.twitter.com/widgets.js" charset="utf-8"}

--- a/app/views/contents/index.html.slim
+++ b/app/views/contents/index.html.slim
@@ -7,7 +7,10 @@
       = alert
   .row.row-eq-height
     - @contents.each do |content|
-      .col-md-4.col-sm-6
+      div class="col-md-4 col-sm-6"
         - case content.provider
-        -            when 'twitter'
-        = raw content.oembed
+        - when 'twitter'
+          blockquote.twitter-tweet data-conversation="none"
+            a href=content.url
+
+script {async src="//platform.twitter.com/widgets.js" charset="utf-8"}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180620040621) do
+ActiveRecord::Schema.define(version: 20190112100838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,7 +36,6 @@ ActiveRecord::Schema.define(version: 20180620040621) do
     t.string "provider", null: false
     t.bigint "source_id", null: false
     t.text "url", null: false
-    t.text "oembed"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
fix #22

## 問題点
事前にAPIで取得したoembedを表示しようとしていたため、表示時に削除等されていた場合、レイアウトが乱れていた

## 変更点

- viewでtweetへのリンクに置き換えとwidgetのスクリプトを読み込みを行う
- jobのoembed登録部分を削除
- dbのoembedカラムを削除